### PR TITLE
Add an instanceof check

### DIFF
--- a/src/main/java/com/nyfaria/nyfsquiver/events/CommonForgeEvents.java
+++ b/src/main/java/com/nyfaria/nyfsquiver/events/CommonForgeEvents.java
@@ -70,7 +70,7 @@ public class CommonForgeEvents {
         }
 
         ItemStack quiverStack = CuriosApi.getCuriosHelper().findEquippedCurio(NyfsQuiver.QUIVER_PREDICATE, e.getEntityLiving()).get().right;
-        if (quiverStack.isEmpty()) {
+        if (quiverStack.isEmpty() || !(quiverStack.getItem() instanceof QuiverItem)) {
             return;
         }
 


### PR DESCRIPTION
Currently if a pack dev allows other mods quivers to go into the quiver curios slot it'll cause a nullpointer when `QuiverItem#getInventory` is called. The instanceof makes sure it won't get to that point if it isn't a quiver from this mod.

An example of the nullpointer that would be fixed:
https://pastebin.com/0cgXQqF2